### PR TITLE
Do not call LWP::Protocol::PSGI#register frequently

### DIFF
--- a/lib/Test/WWW/Stub.pm
+++ b/lib/Test/WWW/Stub.pm
@@ -53,7 +53,7 @@ $app = sub {
 };
 
 sub import {
-    $register_g = LWP::Protocol::PSGI->register($app);
+    $register_g //= LWP::Protocol::PSGI->register($app);
 }
 
 sub register {

--- a/t/10_feature.t
+++ b/t/10_feature.t
@@ -17,6 +17,24 @@ sub test_pass {
     return $results[0]->{ok};
 }
 
+sub lwp_protocol : Tests {
+    subtest 'imported' => sub {
+        my ($premature) = run_tests(sub { ua()->get('http://example.com/') });
+        like $premature, qr/\AUnexpected external access:/, 'diag';
+    };
+    subtest 'imported and unstubbed' => sub {
+        my $g = Test::WWW::Stub->unstub;
+        my ($premature) = run_tests(sub { ua()->get('http://example.com/') });
+        is $premature, '', 'no diag';
+    };
+    subtest 'unstubbed and imported multiple time' => sub {
+        Test::WWW::Stub->import;
+        my $g = Test::WWW::Stub->unstub;
+        my ($premature) = run_tests(sub { ua()->get('http://example.com/') });
+        is $premature, '', 'no diag';
+    };
+}
+
 sub register : Tests {
     my $self = shift;
 


### PR DESCRIPTION
# Problem

If LWP::Protocol::PSGI that has no care of multiple call of `register` is installed and Test::WWW::Stub frequently imported, `Test::WWW::Stub#unstub` does not work.

It means that the tests in this P-R fails.

# How to reproduce it

Install LWP::Protocol::PSGI (<= 0.04) and run tests without the fix

```
cpanm -n -L local/ LWP::Protocol::PSG@0.04
git checkout 1a6d39abdc5bcc149adfa5c3b6061616c88457ac -- lib/Test/WWW/Stub.pm
carton exec -- prove --lib t/
```

# Note

Whether this problem happend or not depend on the environment of this module's consumer because this module specifies no minimum version requirement.

# Solution in this P-R

If the guard created by `LWP::Protocol::PSGI#register` exists, do not call `LWP::Protocol::PSGI#register` again.