### PR TITLE
Prefer warn instead of diag when notice unexpected external access

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Asato Wakisaka <asato.wakisaka@gmail.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v2.3.0, CPAN::Meta::Converter version 2.150001",
+   "generated_by" : "Minilla/v3.0.1, CPAN::Meta::Converter version 2.150001",
    "license" : [
       "perl_5"
    ],
@@ -54,7 +54,8 @@
             "LWP::UserAgent" : "0",
             "Test::Class" : "0",
             "Test::Deep" : "0",
-            "Test::Tester" : "0"
+            "Test::Tester" : "0",
+            "Test::Warnings" : "0"
          }
       }
    },

--- a/README.md
+++ b/README.md
@@ -126,6 +126,6 @@ it under the same terms as Perl itself.
 
 # AUTHOR
 
-Asato Wakisaka <asato.wakisaka@gmail.com>
+Asato Wakisaka &lt;asato.wakisaka@gmail.com>
 
 Original implementation written by suzak.

--- a/cpanfile
+++ b/cpanfile
@@ -9,6 +9,7 @@ on 'test' => sub {
     requires 'Test::Class';
     requires 'Test::Deep';
     requires 'Test::Tester';
+    requires 'Test::Warnings';
     requires 'LWP::UserAgent';
 };
 

--- a/lib/Test/WWW/Stub.pm
+++ b/lib/Test/WWW/Stub.pm
@@ -47,7 +47,7 @@ $app = sub {
     my ($file, $line) = _trace_file_and_line();
 
     my $method = $req->method;
-    Test::More::diag "Unexpected external access: $method $uri at $file line $line";
+    warn "Unexpected external access: $method $uri at $file line $line";
 
     return [ 499, [], [] ];
 };


### PR DESCRIPTION
While using `warn` we can use [Test::Warnings] to make tests failure and immediately fix them.

[Test::Warnings]: http://search.cpan.org/~ether/Test-Warnings-0.024/lib/Test/Warnings.pm