### PR TITLE
Restore to proper state when localize guard object has released in a different order

### DIFF
--- a/lib/Test/WWW/Stub.pm
+++ b/lib/Test/WWW/Stub.pm
@@ -48,15 +48,10 @@ sub import {
 sub register {
     my ($class, $uri_or_re, $app_or_res) = @_;
     $app_or_res //= [200, [], []];
-    my $old_handler = $Intercepter->get_handler($uri_or_re);
 
     $Intercepter->register($uri_or_re, $app_or_res);
     defined wantarray && return guard {
-        if ($old_handler) {
-            $Intercepter->register($uri_or_re, $old_handler);
-        } else {
-            $Intercepter->unregister($uri_or_re);
-        }
+        $Intercepter->unregister($uri_or_re, $app_or_res);
     };
 }
 

--- a/lib/Test/WWW/Stub.pm
+++ b/lib/Test/WWW/Stub.pm
@@ -49,9 +49,9 @@ sub register {
     my ($class, $uri_or_re, $app_or_res) = @_;
     $app_or_res //= [200, [], []];
 
-    $Intercepter->register($uri_or_re, $app_or_res);
+    my $handler = $Intercepter->register($uri_or_re, $app_or_res);
     defined wantarray && return guard {
-        $Intercepter->unregister($uri_or_re, $app_or_res);
+        $Intercepter->unregister($uri_or_re, $handler);
     };
 }
 

--- a/lib/Test/WWW/Stub/Handler.pm
+++ b/lib/Test/WWW/Stub/Handler.pm
@@ -8,10 +8,9 @@ use Scalar::Util qw(blessed);
 
 sub new {
     my ($class, %args) = @_;
-    my $pattern   = $args{pattern};
-    my $app        = $args{app};
-    my $app_or_res = $args{app_or_res};
-    return bless { pattern => $pattern, app => $app, app_or_res => $app_or_res }, $class;
+    my $pattern = $args{pattern};
+    my $app     = $args{app};
+    return bless { pattern => $pattern, app => $app }, $class;
 }
 
 sub factory {
@@ -28,7 +27,7 @@ sub factory {
     } else {
         confess 'Handler MUST be a PSGI app or an ARRAY';
     }
-    return $class->new(pattern => $uri_or_re, app => $app, app_or_res => $app_or_res);
+    return $class->new(pattern => $uri_or_re, app => $app);
 }
 
 sub is_static_pattern {
@@ -66,10 +65,6 @@ sub _match_regexp {
     my @captures = $uri =~ m/$pattern/;
     my $matched = @captures > 0 ? 1 : 0;
     return ($matched, \@captures);
-}
-
-sub app_or_res {
-    return shift->{app_or_res};
 }
 
 1;

--- a/lib/Test/WWW/Stub/Handler.pm
+++ b/lib/Test/WWW/Stub/Handler.pm
@@ -8,9 +8,10 @@ use Scalar::Util qw(blessed);
 
 sub new {
     my ($class, %args) = @_;
-    my $pattern = $args{pattern};
-    my $app     = $args{app};
-    return bless { pattern => $pattern, app => $app }, $class;
+    my $pattern   = $args{pattern};
+    my $app        = $args{app};
+    my $app_or_res = $args{app_or_res};
+    return bless { pattern => $pattern, app => $app, app_or_res => $app_or_res }, $class;
 }
 
 sub factory {
@@ -27,7 +28,7 @@ sub factory {
     } else {
         confess 'Handler MUST be a PSGI app or an ARRAY';
     }
-    return $class->new(pattern => $uri_or_re, app => $app);
+    return $class->new(pattern => $uri_or_re, app => $app, app_or_res => $app_or_res);
 }
 
 sub is_static_pattern {
@@ -65,6 +66,10 @@ sub _match_regexp {
     my @captures = $uri =~ m/$pattern/;
     my $matched = @captures > 0 ? 1 : 0;
     return ($matched, \@captures);
+}
+
+sub app_or_res {
+    return shift->{app_or_res};
 }
 
 1;

--- a/lib/Test/WWW/Stub/Intercepter.pm
+++ b/lib/Test/WWW/Stub/Intercepter.pm
@@ -14,7 +14,7 @@ sub new {
 sub intercept {
     my ($self, $uri, $env, $req) = @_;
     for my $pattern (sort { length $a <=> length $b } keys %{ $self->{registry} }) {
-        continue unless $self->{registry}->{$pattern};
+        next unless $self->{registry}->{$pattern};
         for my $handler (@{$self->{registry}->{$pattern}}) {
             my $maybe_res = $handler->try_call($uri, $env, $req);
             return $maybe_res if $maybe_res;

--- a/lib/Test/WWW/Stub/Intercepter.pm
+++ b/lib/Test/WWW/Stub/Intercepter.pm
@@ -23,12 +23,6 @@ sub intercept {
     return undef;
 }
 
-# who uses?
-sub get_handler {
-    my ($self, $uri_or_re) = @_;
-    return $self->{registry}->{$uri_or_re}->[0];
-}
-
 sub register {
     my ($self, $uri_or_re, $app_or_res) = @_;
     my $handler = Test::WWW::Stub::Handler->factory($uri_or_re, $app_or_res);

--- a/lib/Test/WWW/Stub/Intercepter.pm
+++ b/lib/Test/WWW/Stub/Intercepter.pm
@@ -25,7 +25,7 @@ sub intercept {
 sub register {
     my ($self, $uri_or_re, $app_or_res) = @_;
     my $handler = Test::WWW::Stub::Handler->factory($uri_or_re, $app_or_res);
-    $self->{registry}->{$uri_or_re} = [] unless exists $self->{registry}->{$uri_or_re};
+    $self->{registry}->{$uri_or_re} //= [];
     unshift @{$self->{registry}->{$uri_or_re}}, $handler;
     return $handler;
 }

--- a/lib/Test/WWW/Stub/Intercepter.pm
+++ b/lib/Test/WWW/Stub/Intercepter.pm
@@ -14,7 +14,6 @@ sub new {
 sub intercept {
     my ($self, $uri, $env, $req) = @_;
     for my $pattern (sort { length $a <=> length $b } keys %{ $self->{registry} }) {
-        next unless $self->{registry}->{$pattern};
         for my $handler (@{$self->{registry}->{$pattern}}) {
             my $maybe_res = $handler->try_call($uri, $env, $req);
             return $maybe_res if $maybe_res;

--- a/lib/Test/WWW/Stub/Intercepter.pm
+++ b/lib/Test/WWW/Stub/Intercepter.pm
@@ -2,6 +2,7 @@ package Test::WWW::Stub::Intercepter;
 
 use strict;
 use warnings;
+use List::MoreUtils ();
 
 use Test::WWW::Stub::Handler;
 
@@ -13,27 +14,34 @@ sub new {
 sub intercept {
     my ($self, $uri, $env, $req) = @_;
     for my $pattern (sort { length $a <=> length $b } keys %{ $self->{registry} }) {
-        my $handler = $self->{registry}->{$pattern};
-        my $maybe_res = $handler->try_call($uri, $env, $req);
-        return $maybe_res if $maybe_res;
+        continue unless $self->{registry}->{$pattern};
+        for my $handler (@{$self->{registry}->{$pattern}}) {
+            my $maybe_res = $handler->try_call($uri, $env, $req);
+            return $maybe_res if $maybe_res;
+        }
     }
     return undef;
 }
 
+# who uses?
 sub get_handler {
     my ($self, $uri_or_re) = @_;
-    return $self->{registry}->{$uri_or_re};
+    return $self->{registry}->{$uri_or_re}->[0];
 }
 
 sub register {
     my ($self, $uri_or_re, $app_or_res) = @_;
     my $handler = Test::WWW::Stub::Handler->factory($uri_or_re, $app_or_res);
-    $self->{registry}->{$uri_or_re} = $handler;
+    $self->{registry}->{$uri_or_re} = [] unless exists $self->{registry}->{$uri_or_re};
+    unshift @{$self->{registry}->{$uri_or_re}}, $handler;
 }
 
 sub unregister {
-    my ($self, $uri_or_re) = @_;
-    delete $self->{registry}->{$uri_or_re} if exists $self->{registry}->{$uri_or_re};
+    my ($self, $uri_or_re, $app_or_res) = @_;
+    return unless exists $self->{registry}->{$uri_or_re};
+
+    my $idx = List::MoreUtils::firstidx { $_->app_or_res eq $app_or_res } @{$self->{registry}->{$uri_or_re}};
+    splice @{$self->{registry}->{$uri_or_re}}, $idx, 1;
 }
 
 1;

--- a/lib/Test/WWW/Stub/Intercepter.pm
+++ b/lib/Test/WWW/Stub/Intercepter.pm
@@ -28,13 +28,14 @@ sub register {
     my $handler = Test::WWW::Stub::Handler->factory($uri_or_re, $app_or_res);
     $self->{registry}->{$uri_or_re} = [] unless exists $self->{registry}->{$uri_or_re};
     unshift @{$self->{registry}->{$uri_or_re}}, $handler;
+    return $handler;
 }
 
 sub unregister {
-    my ($self, $uri_or_re, $app_or_res) = @_;
+    my ($self, $uri_or_re, $handler) = @_;
     return unless exists $self->{registry}->{$uri_or_re};
 
-    my $idx = List::MoreUtils::firstidx { $_->app_or_res eq $app_or_res } @{$self->{registry}->{$uri_or_re}};
+    my $idx = List::MoreUtils::firstidx { $_ eq $handler } @{$self->{registry}->{$uri_or_re}};
     splice @{$self->{registry}->{$uri_or_re}}, $idx, 1;
 }
 

--- a/t/11_unregister_bug.t
+++ b/t/11_unregister_bug.t
@@ -18,7 +18,7 @@ sub test_pass {
     return $results[0]->{ok};
 }
 
-sub lwp_protocol : Tests {
+sub issue_19 : Tests {
     my $self = shift;
 
     my $g1 = Test::WWW::Stub->register('https://example.com/OVERRIDE' => [ 500, [], [] ]);

--- a/t/11_unregister_bug.t
+++ b/t/11_unregister_bug.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+use Test::Tester; # Call before any other Test::Builder-based modules
+use Test::More;
+use Test::Deep qw( cmp_deeply methods isa re );
+use Test::Warnings qw(:no_end_test warnings);
+use parent qw( Test::Class );
+
+use Plack::Request;
+use Test::WWW::Stub;
+use LWP::UserAgent;
+
+sub ua { LWP::UserAgent->new; }
+
+sub test_pass {
+    my ($sub) = shift;
+    my ($premature, @results) = run_tests( $sub );
+    return $results[0]->{ok};
+}
+
+sub lwp_protocol : Tests {
+    my $self = shift;
+
+    my $g1 = Test::WWW::Stub->register('https://example.com/OVERRIDE' => [ 500, [], [] ]);
+    {
+        my $code;
+        my $warnings = [ warnings { $code = $self->ua->get('https://example.com/OVERRIDE')->code; } ];
+        cmp_deeply $warnings, [], 'no warnings';
+        is $code, 500, 'stub by g1';
+    }
+
+    my $g2 = Test::WWW::Stub->register('https://example.com/OVERRIDE' => [ 400, [], [] ]);
+    {
+        my $code;
+        my $warnings = [ warnings { $code = $self->ua->get('https://example.com/OVERRIDE')->code; } ];
+        cmp_deeply $warnings, [], 'no warnings';
+        is $code, 400, 'stub by g2';
+    }
+
+    $g1 = undef;
+    {
+        my $code;
+        my $warnings = [ warnings { $code = $self->ua->get('https://example.com/OVERRIDE')->code; } ];
+        cmp_deeply $warnings, [], 'no warnings';
+        is $code, 400, 'still stub by g2';
+    }
+
+    $g2 = undef;
+    {
+        my $code;
+        my $warnings = [ warnings { $code = $self->ua->get('https://example.com/OVERRIDE')->code; } ];
+        cmp_deeply $warnings, [ re('Unexpected external access:') ], 'warnings appeared';
+    }
+}
+
+__PACKAGE__->runtests;

--- a/t/11_unregister_bug.t
+++ b/t/11_unregister_bug.t
@@ -2,11 +2,10 @@ use strict;
 use warnings;
 use Test::Tester; # Call before any other Test::Builder-based modules
 use Test::More;
-use Test::Deep qw( cmp_deeply methods isa re );
+use Test::Deep qw( cmp_deeply re );
 use Test::Warnings qw(:no_end_test warnings);
 use parent qw( Test::Class );
 
-use Plack::Request;
 use Test::WWW::Stub;
 use LWP::UserAgent;
 


### PR DESCRIPTION
fixes #19.

Now Interceptor remembers all registered handlers, and forget it on unregister.